### PR TITLE
Avoid /tmp-based symlink attacks

### DIFF
--- a/hpraid_exporter.go
+++ b/hpraid_exporter.go
@@ -184,8 +184,10 @@ func initTemporaryZipPath() {
 		log.Fatalf("failed to create temporary zip path: %s", err)
 	}
 	log.Debug("Using %s as temporary zip directory", temporaryZipPath)
+}
 
-	// set up signal handler to clean up on kill/Ctrl+C:
+func setupExitHandler() {
+	// Properly clean up before exit'ing on kill or Ctrl+C
 	sigs := make(chan os.Signal, 1)
 	signal.Notify(sigs, syscall.SIGINT, syscall.SIGTERM)
 	go func() {
@@ -212,6 +214,7 @@ func main() {
 
 	initTemporaryZipPath()
 	defer cleanTemporaryZipPath()
+	setupExitHandler()
 	exporter, err := newHpraidExporter(*utilityPath, filepath.Join(temporaryZipPath, "hpraid_exporter.zip"))
 	if err != nil {
 		panic(err)


### PR DESCRIPTION
Instead of using a predictable, constant path for writing the temporary
zip file, use ioutil.TempDir to create an appropriate directory on
startup. We also ensure that it is properly deleted if startup fails or
the exporter is killed / aborted using Ctrl+C.

Fixes issue #1.

Please note that I do not actually run this exporter. I do not even have HP hardware around me. Therefore, all the testing I was able to do were with some substitute `ssacli` script. I suggest proper testing with the real tool before merging.